### PR TITLE
fix: unwrap charset at-rule from media query

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,11 @@ const vueMediaLoader: loader.Loader = function vueMediaLoader(code) {
     return code
   }
 
-  return `@media ${options.media} {\n${code}\n}`
+  const str = String(code)
+  const matched = str.match(/^\s*@charset\s*('.*'|".*")\s*;\s*/)
+  const charset = matched ? matched[0] : ''
+  const body = str.replace(charset, '')
+
+  return `${charset}@media ${options.media} {\n${body}\n}`
 }
 export = vueMediaLoader

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -35,6 +35,15 @@ describe('vue-media-loader', () => {
     expect(res).toBe(code)
   })
 
+  it('extracts charset at-rule', () => {
+    const code = '@charset "UTF-8";\n.foo { color: red; }'
+    const media = 'print'
+    const res = load(code, './Test.vue?vue&media=' + encodeURIComponent(media))
+    expect(res).toBe(
+      `@charset "UTF-8";\n@media ${media} {\n.foo { color: red; }\n}`
+    )
+  })
+
   it('not throws when query is not passed', () => {
     const code = '.foo { color: red; }'
     const res = load(code, './Test.vue')


### PR DESCRIPTION
If the input css has `@charset` at-rule, the output css will be invalid when we naively wrap entire file with media query.

In this change, it will extract the charset and prevent to be in media query. The extracting logic is a bit naive but I think it would work in most cases.